### PR TITLE
Update fn_Init.sqf

### DIFF
--- a/saef_radiation/Functions/fn_Init.sqf
+++ b/saef_radiation/Functions/fn_Init.sqf
@@ -8,11 +8,11 @@ _compatGasMasks =
 [
 	["G_mas_idf_gasmask", "Gasmask_RoundEye"],
 	["G_mas_idf_gasmask_C", "Gasmask_RoundEye"],
-	["G_RegulatorMask_F", "Gasmask_FlatEye"],
-	["G_AirPurifyingRespirator_02_black_F", "Gasmask_FlatEye"],
-	["G_AirPurifyingRespirator_02_olive_F", "Gasmask_FlatEye"],
-	["G_AirPurifyingRespirator_02_sand_F", "Gasmask_FlatEye"],
-	["G_AirPurifyingRespirator_01_F", "Gasmask_FlatEye"]
+	["G_RegulatorMask_F", "RscCBRN_Regulator"],
+	["G_AirPurifyingRespirator_02_black_F", "RscCBRN_APR_02"],
+	["G_AirPurifyingRespirator_02_olive_F", "RscCBRN_APR_02"],
+	["G_AirPurifyingRespirator_02_sand_F", "RscCBRN_APR_02"],
+	["G_AirPurifyingRespirator_01_F", "RscCBRN_APR"]
 ];
 
 // SP Debug


### PR DESCRIPTION
changed the APR[NATO] to use the APR overlay, the APR[CSAT]+colors to use the APR_02 overlay, and the regulator to use the regulator overlays